### PR TITLE
WIP: Add broken and redirected link rule

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+FROM php:7.4-fpm
+ARG ENVIORNMENT_TYPE
+
+#Install dependencies and php extensions
+RUN apt-get update && apt-get install -y \
+        git \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libpng-dev \
+        libpq-dev \
+        unzip \
+        wget \
+        supervisor \
+        apache2 \
+    && docker-php-ext-configure gd  \
+    && docker-php-ext-install -j$(nproc) gd
+
+#Install AWS CLI v2
+RUN if [ "$ENVIORNMENT_TYPE" != "local" ] ;then  \
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+        && unzip awscliv2.zip \
+        && ./aws/install\
+    ;fi
+
+RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
+RUN apachectl start
+
+#Create user ssm-user
+RUN useradd -ms /bin/bash ssm-user
+RUN mkdir -p /var/www/html \
+    && chown ssm-user:www-data /var/www/html
+
+#install composer
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+
+#Copy over files
+COPY --chown=ssm-user:www-data . /var/www/html/
+
+WORKDIR /var/www/html
+#run setup script
+RUN chmod +x deploy/udoit-ng.sh
+RUN deploy/udoit-ng.sh
+
+CMD php-fpm

--- a/deploy/udoit-ng.sh
+++ b/deploy/udoit-ng.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# change to the new file location
+cd /var/www/html
+
+# copy localConfig from S3 if you are not on local
+if [ "$ENVIORNMENT_TYPE" != "local" ]
+then
+    aws s3 cp s3://cidilabs-devops/udoit3/.env.local.$ENVIORNMENT_TYPE /var/www/html/.env.local
+fi
+
+# run composer install
+composer install --no-dev --no-interaction --no-progress --optimize-autoloader
+
+# change all file and directory permissions to give apache sufficient access
+sudo find /var/www/html -type f -exec chmod 664 {} + -o -type d -exec chmod 775 {} +
+
+# only setup newrelic if not on local.
+if [ "$ENVIORNMENT_TYPE" != "local" ]
+then
+    # create .user.ini file for New Relic (PHP-FPM only)
+    touch /var/www/html/public/.user.ini
+    # add New Relic appname
+    echo -e "\nnewrelic.appname = \"$NEW_RELIC_APP_NAME\"" >> /var/www/html/public/.user.ini
+fi
+
+# start queue monitor
+/usr/bin/supervisord
+
+# restart apaches
+# apachectl restart

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.3'
+
+services:
+  php:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/var/www/html
+    ports:
+      - "8000:8000"
+volumes:
+  web:
+  dbdata:

--- a/src/Rule/BrokenRedirectedLink.php
+++ b/src/Rule/BrokenRedirectedLink.php
@@ -42,7 +42,7 @@ class BrokenRedirectedLink extends BaseRule
 			$status = curl_getinfo($curls[$i], CURLINFO_HTTP_CODE);
 			if ($link != $redirect) {
 				// Redirected link (May be a Canvas link that is not actually redirected)
-				$this->setIssue($links[$link], $metadata = $redirect);
+				$this->setIssue($links[$link], null, json_encode(array('redirect_url' => $redirect)));
 			}
 			if (404 == $status) {
 				$this->setIssue($links[$link]);

--- a/src/Rule/BrokenRedirectedLink.php
+++ b/src/Rule/BrokenRedirectedLink.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace CidiLabs\PhpAlly\Rule;
+
+use DOMElement;
+
+/**
+*
+*/
+class BrokenRedirectedLink extends BaseRule
+{
+
+
+	public function id()
+	{
+		return self::class;
+	}
+
+	public function check()
+	{
+		foreach ($this->getAllElements('a') as $a) {
+			$link = $a->getAttribute('href');
+			if ($link) {
+				$this->setIssue($a);
+			}
+		}
+
+		return count($this->issues);
+	}
+
+}

--- a/src/Rule/BrokenRedirectedLink.php
+++ b/src/Rule/BrokenRedirectedLink.php
@@ -5,27 +5,64 @@ namespace CidiLabs\PhpAlly\Rule;
 use DOMElement;
 
 /**
-*
+*  Links that are broken need to be removed or manually updated.
+*  Links that are redirected should be updated with the new link.
+*  Based on UDOIT 2.8.X https://github.com/ucfopen/UDOIT/blob/classic/lib/Udoit.php
+*  contributions by Emily Sachs
 */
 class BrokenRedirectedLink extends BaseRule
 {
-
 
 	public function id()
 	{
 		return self::class;
 	}
 
+	private function linkCheck($links) {
+		$curls = array();
+		$mcurl = curl_multi_init();
+		foreach (array_keys($links) as $i => $link) {
+			$curls[$i] = curl_init();
+			curl_setopt($curls[$i], CURLOPT_URL, $link);
+			curl_setopt($curls[$i], CURLOPT_HEADER, true);
+			curl_setopt($curls[$i], CURLOPT_NOBODY, true);
+			curl_setopt($curls[$i], CURLOPT_REFERER, true);
+			curl_setopt($curls[$i], CURLOPT_TIMEOUT, 2);
+			curl_setopt($curls[$i], CURLOPT_AUTOREFERER, true);
+			curl_setopt($curls[$i], CURLOPT_RETURNTRANSFER, true);
+			curl_setopt($curls[$i], CURLOPT_FOLLOWLOCATION, true);
+			curl_multi_add_handle($mcurl, $curls[$i]);
+		}
+		$running = null;
+		do {
+			curl_multi_exec($mcurl, $running);
+		} while ($running > 0);
+		foreach (array_keys($links) as $i => $link) {
+			$redirect = curl_getinfo($curls[$i], CURLINFO_EFFECTIVE_URL);
+			$status = curl_getinfo($curls[$i], CURLINFO_HTTP_CODE);
+			if ($link != $redirect) {
+				// Redirected link (May be a Canvas link that is not actually redirected)
+				$this->setIssue($links[$link], $metadata = $redirect);
+			}
+			if (404 == $status) {
+				$this->setIssue($links[$link]);
+			}
+			curl_multi_remove_handle($mcurl, $curls[$i]);
+		}
+		curl_multi_close($mcurl);
+	}
+
 	public function check()
 	{
+		$links = array();
 		foreach ($this->getAllElements('a') as $a) {
-			$link = $a->getAttribute('href');
-			if ($link) {
-				$this->setIssue($a);
+			$href = $a->getAttribute('href');
+			if ($href) {
+				$links[$href] = $a; // href should exclude start with '#'
 			}
 		}
+		$this->linkCheck($links);
 
 		return count($this->issues);
 	}
-
 }

--- a/src/Rule/BrokenRedirectedLink.php
+++ b/src/Rule/BrokenRedirectedLink.php
@@ -42,7 +42,15 @@ class BrokenRedirectedLink extends BaseRule
 			$status = curl_getinfo($curls[$i], CURLINFO_HTTP_CODE);
 			if ($link != $redirect) {
 				// Redirected link (May be a Canvas link that is not actually redirected)
-				$this->setIssue($links[$link], null, json_encode(array('redirect_url' => $redirect)));
+				$ref = $redirect;
+				preg_match('/^[^#\s]+/', $ref, $matches);
+				$base = $matches[0];
+				$base = preg_replace('/\/$/', '', $base);
+				$base = preg_replace('/www\./', '', $base);
+				$base = preg_replace('/http[s]{0,1}:\/\//', '', $base);
+				if (strpos($link, $base) === false) {
+					$this->setIssue($links[$link], null, json_encode(array('redirect_url' => $redirect)));
+				}
 			}
 			if (404 == $status) {
 				$this->setIssue($links[$link]);

--- a/tests/BrokenRedirectedLinkTest.php
+++ b/tests/BrokenRedirectedLinkTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use CidiLabs\PhpAlly\Rule\BrokenRedirectedLink;
+
+class BrokenRedirectedLinkTest extends PhpAllyTestCase {
+    public function testCheckAlive()
+    {
+        $html = '<div><a href="https://google.com/">I am a link.</a><div>';
+        $dom = new \DOMDocument('1.0', 'utf-8');
+        $dom->loadHTML($html);
+        $rule = new BrokenRedirectedLink($dom);
+
+        $this->assertEquals(1, $rule->check(), 'Broken or Redirected Link should have one issue.');
+    }
+}

--- a/tests/BrokenRedirectedLinkTest.php
+++ b/tests/BrokenRedirectedLinkTest.php
@@ -3,9 +3,29 @@
 use CidiLabs\PhpAlly\Rule\BrokenRedirectedLink;
 
 class BrokenRedirectedLinkTest extends PhpAllyTestCase {
-    public function testCheckAlive()
+    public function testCheckBroken()
     {
-        $html = '<div><a href="https://google.com/">I am a link.</a><div>';
+        $html = '<div><a href="https://webaim.org/brokenlink">I am a link.</a><div>';
+        $dom = new \DOMDocument('1.0', 'utf-8');
+        $dom->loadHTML($html);
+        $rule = new BrokenRedirectedLink($dom);
+
+        $this->assertEquals(1, $rule->check(), 'Broken or Redirected Link should have one issue.');
+    }
+
+    public function testCheckNotRedirected()
+    {
+        $html = '<div><a href="www.google.com">I am a link.</a><div>';
+        $dom = new \DOMDocument('1.0', 'utf-8');
+        $dom->loadHTML($html);
+        $rule = new BrokenRedirectedLink($dom);
+
+        $this->assertEquals(0, $rule->check(), 'Broken or Redirected Link should have no issue.');
+    }
+
+    public function testCheckRedirected()
+    {
+        $html = '<div><a href="https://online.ucf.edu/udoit">I am a link.</a><div>';
         $dom = new \DOMDocument('1.0', 'utf-8');
         $dom->loadHTML($html);
         $rule = new BrokenRedirectedLink($dom);


### PR DESCRIPTION
Add rule to test links within the `href` attribute of the `a` tag to see if it is broken, or redirects to a different page, as in UDOIT 2.8.  This case likely can not cover within-lms links.