### PR TITLE
Add test checking that a redirect link is contained in metadata

### DIFF
--- a/tests/BrokenRedirectedLinkTest.php
+++ b/tests/BrokenRedirectedLinkTest.php
@@ -32,4 +32,21 @@ class BrokenRedirectedLinkTest extends PhpAllyTestCase {
 
         $this->assertEquals(1, $rule->check(), 'Broken or Redirected Link should have one issue.');
     }
+
+    public function testCheckRedirectedAndMetadata()
+    {
+        $html = '<div><a href="https://online.ucf.edu/udoit">I am a link.</a><div>';
+        $dom = new \DOMDocument('1.0', 'utf-8');
+        $dom->loadHTML($html);
+        $rule = new BrokenRedirectedLink($dom);
+
+        // Check if metadata is present with a new link
+        $result = $rule->check();
+        if ($rule->getIssues() && count($rule->getIssues()) == 1) {
+            $meta = $rule->getIssues()[0]->getMetadata();
+            $result = 1 + $result;
+        }
+
+        $this->assertEquals(2, $result, 'Broken or Redirected Link should have one issue.');
+    }
 }


### PR DESCRIPTION
Checks to make sure that if a link is marked as redirected, the issue metadata contains the new link.